### PR TITLE
feat: add support for generating simple formulas for anything

### DIFF
--- a/.justfile
+++ b/.justfile
@@ -31,7 +31,7 @@ tag BUMP:
 	#!/usr/bin/env bash
 	set -e
 	current=$(tomato get package.version Cargo.toml)
-	version=$(echo "$current" | semver-bump {{BUMP}})
+	version=$(semver-bump {{BUMP}} "$current")
 	tomato set package.version "$version" Cargo.toml &> /dev/null
 	cargo generate-lockfile
 	git commit Cargo.toml Cargo.lock -m "v${version}"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,7 +125,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "374b7c592d9c00c1f4972ea58390ac6b18cbb6ab79011f3bdc90a0b82ca06b77"
 dependencies = [
  "serde",
- "toml",
+ "toml 0.9.5",
 ]
 
 [[package]]
@@ -386,7 +386,9 @@ dependencies = [
  "hex",
  "roctogen",
  "roctokit",
+ "serde",
  "sha2",
+ "toml 0.8.23",
  "upon",
  "ureq",
 ]
@@ -896,6 +898,15 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40734c41988f7306bb04f0ecf60ec0f3f1caa34290e4e8ea471dcd3346483b83"
@@ -1051,17 +1062,38 @@ dependencies = [
 
 [[package]]
 name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75129e1dc5000bfbaa9fee9d1b21f974f9fbad9daec557a521ee6e080825f6e8"
 dependencies = [
  "indexmap",
  "serde",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 1.0.0",
+ "toml_datetime 0.7.0",
  "toml_parser",
  "toml_writer",
  "winnow",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -1074,6 +1106,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
 name = "toml_parser"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1081,6 +1127,12 @@ checksum = "b551886f449aa90d4fe2bdaa9f4a2577ad2dde302c61ecf262d80b116db95c10"
 dependencies = [
  "winnow",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
@@ -1543,6 +1595,9 @@ name = "winnow"
 version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "writeable"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,12 +9,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
-name = "android-tzdata"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
-
-[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -25,9 +19,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.20"
+version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae563653d1938f79b1ab1b5e668c87c76a9930414574a6583a7b7e11a8e6192"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -40,9 +34,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.11"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
 
 [[package]]
 name = "anstyle-parse"
@@ -55,29 +49,29 @@ dependencies = [
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.10"
+version = "3.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.99"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
+checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
 
 [[package]]
 name = "autocfg"
@@ -93,9 +87,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
-version = "2.9.1"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "block-buffer"
@@ -108,15 +102,15 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.19.0"
+version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cargo_toml"
@@ -125,15 +119,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "374b7c592d9c00c1f4972ea58390ac6b18cbb6ab79011f3bdc90a0b82ca06b77"
 dependencies = [
  "serde",
- "toml 0.9.5",
+ "toml 0.9.12+spec-1.1.0",
 ]
 
 [[package]]
 name = "cc"
-version = "1.2.32"
+version = "1.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2352e5597e9c544d5e6d9c95190d5d27738ade584fa8db0a16e130e5c2b5296e"
+checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
 dependencies = [
+ "find-msvc-tools",
  "shlex",
 ]
 
@@ -145,17 +140,16 @@ checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "cfg-if"
-version = "1.0.1"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chrono"
-version = "0.4.41"
+version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
+checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
 dependencies = [
- "android-tzdata",
  "iana-time-zone",
  "js-sys",
  "num-traits",
@@ -166,9 +160,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.45"
+version = "4.5.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc0e74a703892159f5ae7d3aac52c8e6c392f5ae5f359c70b5881d60aaac318"
+checksum = "63be97961acde393029492ce0be7a1af7e323e6bae9511ebfac33751be5e6806"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -176,9 +170,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.44"
+version = "4.5.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3e7f4214277f3c7aa526a59dd3fbe306a370daee1f8b7b8c987069cd8e888a8"
+checksum = "7f13174bda5dfd69d7e947827e5af4b0f2f94a4a3ee92912fba07a66150f21e2"
 dependencies = [
  "anstream",
  "anstyle",
@@ -189,9 +183,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.45"
+version = "4.5.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14cb31bb0a7d536caef2639baa7fad459e15c3144efefa6dbd1c84562c4739f6"
+checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -201,9 +195,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.5"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
+checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "colorchoice"
@@ -217,7 +211,7 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
 dependencies = [
- "cfg-if 1.0.1",
+ "cfg-if 1.0.4",
  "wasm-bindgen",
 ]
 
@@ -245,9 +239,9 @@ dependencies = [
 
 [[package]]
 name = "cookie_store"
-version = "0.21.1"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eac901828f88a5241ee0600950ab981148a18f2f756900ffba1b125ca6a3ef9"
+checksum = "3fc4bff745c9b4c7fb1e97b25d13153da2bc7796260141df62378998d070207f"
 dependencies = [
  "cookie",
  "document-features",
@@ -282,14 +276,14 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
- "cfg-if 1.0.1",
+ "cfg-if 1.0.4",
 ]
 
 [[package]]
 name = "crypto-common"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
@@ -297,9 +291,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.4.0"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
+checksum = "cc3dc5ad92c2e2d1c193bbbbdf2ea477cb81331de4f3103f267ca18368b988c4"
 dependencies = [
  "powerfmt",
 ]
@@ -327,9 +321,9 @@ dependencies = [
 
 [[package]]
 name = "document-features"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95249b50c6c185bee49034bcb378a49dc2b5dff0be90ff6616d31d64febab05d"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
 dependencies = [
  "litrs",
 ]
@@ -342,35 +336,35 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
-name = "flate2"
-version = "1.1.2"
+name = "find-msvc-tools"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
 ]
 
 [[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
 name = "form_urlencoded"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
@@ -388,9 +382,33 @@ dependencies = [
  "roctokit",
  "serde",
  "sha2",
- "toml 0.8.23",
+ "toml 1.0.1+spec-1.1.0",
  "upon",
  "ureq",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
 ]
 
 [[package]]
@@ -405,20 +423,20 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
- "cfg-if 1.0.1",
+ "cfg-if 1.0.4",
  "libc",
  "wasi",
 ]
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "heck"
@@ -434,12 +452,11 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
 dependencies = [
  "bytes",
- "fnv",
  "itoa",
 ]
 
@@ -451,9 +468,9 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.63"
+version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -475,9 +492,9 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
 dependencies = [
  "displaydoc",
  "potential_utf",
@@ -488,9 +505,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cde2700ccaed3872079a65fb1a78f6c0a36c91570f28755dda67bc8f7d9f00a"
+checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -501,11 +518,10 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "436880e8e18df4d7bbc06d58432329d6458cc84531f7ac5f024e93deadb37979"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
 dependencies = [
- "displaydoc",
  "icu_collections",
  "icu_normalizer_data",
  "icu_properties",
@@ -516,42 +532,38 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
 
 [[package]]
 name = "icu_properties"
-version = "2.0.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "016c619c1eeb94efb86809b015c58f479963de65bdb6253345c1a1276f22e32b"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
 dependencies = [
- "displaydoc",
  "icu_collections",
  "icu_locale_core",
  "icu_properties_data",
  "icu_provider",
- "potential_utf",
  "zerotrie",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_properties_data"
-version = "2.0.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
 
 [[package]]
 name = "icu_provider"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03c80da27b5f4187909049ee2d72f276f0d9f99a42c306bd0131ecfe04d8e5af"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
- "stable_deref_trait",
- "tinystr",
  "writeable",
  "yoke",
  "zerofrom",
@@ -561,9 +573,9 @@ dependencies = [
 
 [[package]]
 name = "idna"
-version = "1.0.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
 dependencies = [
  "idna_adapter",
  "smallvec",
@@ -582,9 +594,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.10.0"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -592,21 +604,21 @@ dependencies = [
 
 [[package]]
 name = "is_terminal_polyfill"
-version = "1.70.1"
+version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itoa"
-version = "1.0.15"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "js-sys"
-version = "0.3.77"
+version = "0.3.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -614,39 +626,39 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.175"
+version = "0.2.182"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
+checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.9.4"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "litemap"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
+checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "litrs"
-version = "0.4.2"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5e54036fe321fd421e10d732f155734c4e4afd610dd556d9a82833ab3ee0bed"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "log"
-version = "0.4.27"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "memchr"
-version = "2.7.5"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memory_units"
@@ -661,13 +673,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
 
 [[package]]
 name = "num-traits"
@@ -686,21 +699,27 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "once_cell_polyfill"
-version = "1.70.1"
+version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "percent-encoding"
-version = "2.3.1"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "potential_utf"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5a7c30837279ca13e7c867e9e40053bc68740f988cb07f7ca6df43cc734b585"
+checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
 dependencies = [
  "zerovec",
 ]
@@ -713,18 +732,18 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.97"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d61789d7719defeb74ea5fe81f2fdfdbd28a803847077cecce2ff14e1472f6f1"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
 dependencies = [
  "proc-macro2",
 ]
@@ -736,7 +755,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
- "cfg-if 1.0.1",
+ "cfg-if 1.0.4",
  "getrandom",
  "libc",
  "untrusted",
@@ -745,12 +764,12 @@ dependencies = [
 
 [[package]]
 name = "roctogen"
-version = "0.36.0"
+version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80a26d8f873ff236cba3ae1e17a7574da650e4999b9f3f0dfd5cfb89181da12b"
+checksum = "f24983b0843dbd1c35ae42dbded7f878e2c89054e5cddf3e19dd2890af7ea7e9"
 dependencies = [
  "base64",
- "cfg-if 1.0.1",
+ "cfg-if 1.0.4",
  "chrono",
  "console_error_panic_hook",
  "console_log",
@@ -776,7 +795,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee2507405af6388b6691f1edb4f448735c341fbe5f63110b730583c9d3d4ddc8"
 dependencies = [
  "base64",
- "cfg-if 1.0.1",
+ "cfg-if 1.0.4",
  "chrono",
  "console_error_panic_hook",
  "console_log",
@@ -797,22 +816,22 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.8"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
+checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
 dependencies = [
  "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.31"
+version = "0.23.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ebcbd2f03de0fc1122ad9bb24b127a5a6cd51d72604a3f3c50ac459762b6cc"
+checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
 dependencies = [
  "log",
  "once_cell",
@@ -824,28 +843,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
 name = "rustls-pki-types"
-version = "1.12.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
  "zeroize",
 ]
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.4"
+version = "0.103.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a17884ae0c1b773f1ccd2bd4a8c72f16da897310a98b0e84bf349ad5ead92fc"
+checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -860,24 +870,34 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
-version = "1.0.20"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -886,32 +906,24 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.142"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "030fedb782600dcbd6f02d479bf0d817ac3bb40d644745b769d6a96bc3afc5a7"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.9"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
 dependencies = [
- "serde",
-]
-
-[[package]]
-name = "serde_spanned"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40734c41988f7306bb04f0ecf60ec0f3f1caa34290e4e8ea471dcd3346483b83"
-dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -932,7 +944,7 @@ version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
- "cfg-if 1.0.1",
+ "cfg-if 1.0.4",
  "cpufeatures",
  "digest",
 ]
@@ -944,6 +956,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -951,9 +975,9 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "stable_deref_trait"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "strsim"
@@ -969,9 +993,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.104"
+version = "2.0.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
+checksum = "3df424c70518695237746f84cede799c9c58fcb37450d7b23716568cc8bc69cb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1021,30 +1045,30 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.41"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
  "num-conv",
  "powerfmt",
- "serde",
+ "serde_core",
  "time-core",
  "time-macros",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.4"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.22"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
@@ -1052,9 +1076,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
+checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -1062,26 +1086,29 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.23"
+version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
- "serde",
- "serde_spanned 0.6.9",
- "toml_datetime 0.6.11",
- "toml_edit",
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
 ]
 
 [[package]]
 name = "toml"
-version = "0.9.5"
+version = "1.0.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75129e1dc5000bfbaa9fee9d1b21f974f9fbad9daec557a521ee6e080825f6e8"
+checksum = "bbe30f93627849fa362d4a602212d41bb237dc2bd0f8ba0b2ce785012e124220"
 dependencies = [
  "indexmap",
- "serde",
- "serde_spanned 1.0.0",
- "toml_datetime 0.7.0",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime 1.0.0+spec-1.1.0",
  "toml_parser",
  "toml_writer",
  "winnow",
@@ -1089,74 +1116,54 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.11"
+version = "0.7.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.7.0"
+version = "1.0.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bade1c3e902f58d73d3f294cd7f20391c1cb2fbcb643b73566bc773971df91e3"
+checksum = "32c2555c699578a4f59f0cc68e5116c8d7cabbd45e1409b989d4be085b53f13e"
 dependencies = [
- "serde",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.22.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
-dependencies = [
- "indexmap",
- "serde",
- "serde_spanned 0.6.9",
- "toml_datetime 0.6.11",
- "toml_write",
- "winnow",
+ "serde_core",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.2"
+version = "1.0.8+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b551886f449aa90d4fe2bdaa9f4a2577ad2dde302c61ecf262d80b116db95c10"
+checksum = "0742ff5ff03ea7e67c8ae6c93cac239e0d9784833362da3f9a9c1da8dfefcbdc"
 dependencies = [
  "winnow",
 ]
 
 [[package]]
-name = "toml_write"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
-
-[[package]]
 name = "toml_writer"
-version = "1.0.2"
+version = "1.0.6+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc842091f2def52017664b53082ecbbeb5c7731092bad69d2c63050401dfd64"
+checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
 
 [[package]]
 name = "typenum"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.18"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+checksum = "537dd038a89878be9b64dd4bd1b260315c1bb94f4d784956b81e27a088d9a09e"
 
 [[package]]
 name = "unicode-width"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "untrusted"
@@ -1166,9 +1173,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "upon"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc1243af2969e332d5b9b99087eddd44d04a41da8630ed53e06df497b7f5c747"
+checksum = "f3ead40aa15464f4d808014183fa0b030761ff6f57e162f7fc76d6a900df7a28"
 dependencies = [
  "serde",
  "unicode-ident",
@@ -1177,9 +1184,9 @@ dependencies = [
 
 [[package]]
 name = "ureq"
-version = "3.0.12"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f0fde9bc91026e381155f8c67cb354bcd35260b2f4a29bcc84639f762760c39"
+checksum = "fdc97a28575b85cfedf2a7e7d3cc64b3e11bd8ac766666318003abbacc7a21fc"
 dependencies = [
  "base64",
  "cookie_store",
@@ -1187,20 +1194,19 @@ dependencies = [
  "log",
  "percent-encoding",
  "rustls",
- "rustls-pemfile",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "ureq-proto",
  "utf-8",
- "webpki-roots 0.26.11",
+ "webpki-roots",
 ]
 
 [[package]]
 name = "ureq-proto"
-version = "0.4.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59db78ad1923f2b1be62b6da81fe80b173605ca0d57f85da2e005382adf693f7"
+checksum = "d81f9efa9df032be5934a46a068815a10a042b494b6a58cb0a1a97bb5467ed6f"
 dependencies = [
  "base64",
  "http",
@@ -1210,13 +1216,14 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.5.4"
+version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
 dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]
@@ -1251,39 +1258,27 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.100"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
 dependencies = [
- "cfg-if 1.0.1",
+ "cfg-if 1.0.4",
  "once_cell",
  "rustversion",
  "serde",
  "serde_json",
  "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
-dependencies = [
- "bumpalo",
- "log",
- "proc-macro2",
- "quote",
- "syn",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.50"
+version = "0.4.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
+checksum = "70a6e77fd0ae8029c9ea0063f87c46fde723e7d887703d74ad2616d792e51e6f"
 dependencies = [
- "cfg-if 1.0.1",
+ "cfg-if 1.0.4",
+ "futures-util",
  "js-sys",
  "once_cell",
  "wasm-bindgen",
@@ -1292,9 +1287,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.100"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1302,31 +1297,31 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.100"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
 dependencies = [
+ "bumpalo",
  "proc-macro2",
  "quote",
  "syn",
- "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.100"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.77"
+version = "0.3.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1334,18 +1329,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.11"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
-dependencies = [
- "webpki-roots 1.0.2",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8983c3ab33d6fb807cfcdad2491c4ea8cbc8ed839181c7dfd9c67c83e261b2"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -1386,9 +1372,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
-version = "0.61.2"
+version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement",
  "windows-interface",
@@ -1399,9 +1385,9 @@ dependencies = [
 
 [[package]]
 name = "windows-implement"
-version = "0.60.0"
+version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1410,9 +1396,9 @@ dependencies = [
 
 [[package]]
 name = "windows-interface"
-version = "0.59.1"
+version = "0.59.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1421,24 +1407,24 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
-version = "0.1.3"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-result"
-version = "0.3.4"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
  "windows-link",
 ]
 
 [[package]]
 name = "windows-strings"
-version = "0.4.2"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
  "windows-link",
 ]
@@ -1458,7 +1444,16 @@ version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets 0.53.3",
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -1479,19 +1474,19 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.3"
+version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
  "windows-link",
- "windows_aarch64_gnullvm 0.53.0",
- "windows_aarch64_msvc 0.53.0",
- "windows_i686_gnu 0.53.0",
- "windows_i686_gnullvm 0.53.0",
- "windows_i686_msvc 0.53.0",
- "windows_x86_64_gnu 0.53.0",
- "windows_x86_64_gnullvm 0.53.0",
- "windows_x86_64_msvc 0.53.0",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -1502,9 +1497,9 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -1514,9 +1509,9 @@ checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1526,9 +1521,9 @@ checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
 
 [[package]]
 name = "windows_i686_gnullvm"
@@ -1538,9 +1533,9 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_gnullvm"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1550,9 +1545,9 @@ checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1562,9 +1557,9 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -1574,9 +1569,9 @@ checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -1586,32 +1581,28 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "0.7.12"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95"
-dependencies = [
- "memchr",
-]
+checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 
 [[package]]
 name = "writeable"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
+checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "yoke"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc"
+checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
 dependencies = [
- "serde",
  "stable_deref_trait",
  "yoke-derive",
  "zerofrom",
@@ -1619,9 +1610,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
+checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1652,15 +1643,15 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.1"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36f0bbd478583f79edad978b407914f61b2972f5af6fa089686016be8f9af595"
+checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -1669,9 +1660,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.4"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7aa2bd55086f1ab526693ecbe444205da57e25f4489879da80635a46d90e73b"
+checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -1680,11 +1671,17 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
+checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,12 +15,12 @@ cargo_toml = "0.22.1"
 clap = { version = "4.5.39", features = ["derive", "wrap_help"] }
 heck = "0.5.0"
 hex = "0.4.3"
-roctogen = "0.36.0"
+roctogen = "0.50.0"
 roctokit = { version = "0.15.0", features = ["ureq"] }
 serde = { version = "1", features = ["derive"] }
 sha2 = "0.10.9"
-toml = "0.8"
-upon = "0.9.0"
+toml = "1.0"
+upon = "0.10.0"
 ureq = "3.0.11"
 
 [lints.rust]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,9 @@ heck = "0.5.0"
 hex = "0.4.3"
 roctogen = "0.36.0"
 roctokit = { version = "0.15.0", features = ["ureq"] }
+serde = { version = "1", features = ["derive"] }
 sha2 = "0.10.9"
+toml = "0.8"
 upon = "0.9.0"
 ureq = "3.0.11"
 

--- a/README.md
+++ b/README.md
@@ -1,33 +1,57 @@
 # formulaic
 
-`formulaic` is a cli that reads a manifest for a Rust program plus GitHub release information, and generates a homebrew formula for downloading assets for it. It is intended to be run in a GitHub action that's generating the release, though it can also be run locally after a release has been created. It is yet another tool in a long series of tools that solve extremely specific problems that nobody else has.
+`formulaic` generates Homebrew formula files from GitHub release assets. It supports Rust projects via `Cargo.toml` and any project via a `formulaic.toml` manifest. It is intended to be run in a GitHub action that's generating a release, though it can also be run locally after a release has been created.
 
 ## Usage
 
-Create a GitHub personal access token with _read_ access to the repository you're creating formulas for. Give it _write_ access to your Homebrew tap repo if you're also using this token in a workflow that updates the tap. Export that token in the env var `GITHUB_ACCESS_TOKEN`. Then invoke the tool with the location of the `Cargo.toml` manifest for the thing whose tap you want to update.
+Create a GitHub personal access token with _read_ access to the repository you're creating formulas for. Give it _write_ access to your Homebrew tap repo if you're also using this token in a workflow that updates the tap. Export that token as `GITHUB_ACCESS_TOKEN` or `GITHUB_TOKEN`.
 
-`formulaic` writes a single file to the working directory in which it is invoked, then outputs the name of that file to `stdout`. The file is named `{executable}.rb`, for the first bin target it finds in the cargo manifest.
-
-If you set the `--gh-cli-strategy`, the tool will generate a formula file with an embedded custom download strategy that uses the `gh` [github command-line tool](https://cli.github.com). You can use an authenticated `gh` to download release artifacts from private repos, assuming you can tap the private repo to begin with.
-
-```text
-Usage: formulaic [OPTIONS] [MANIFEST]
-
-Arguments:
-  [MANIFEST]
-          path to the Cargo.toml file for the installable binary
-          [default: ./Cargo.toml]
-
-Options:
-  -g, --gh-cli-strategy
-          Use the `gh` cli download strategy; useful for private tap repos
-  -l, --local
-          If you have no repo-reading API permissions, we'll use only local data
-  -h, --help
-          Print help (see a summary with '-h')
-  -V, --version
-          Print version
 ```
+formulaic [OPTIONS] [MANIFEST]
+```
+
+If no manifest path is given, formulaic searches the current directory in this order:
+
+1. `.config/formulaic.toml`
+2. `.formulaic.toml`
+3. `formulaic.toml`
+4. `Cargo.toml`
+
+The tool writes `{executable}.rb` to the working directory (or `--output-dir`) and prints the path to stdout. Use `--dry-run` to preview without writing.
+
+### Options
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--gh-cli-strategy` | `-g` | Use the `gh` CLI download strategy (useful for private repos) |
+| `--local` | `-l` | Use only local data from a `dist/` directory instead of the GitHub API |
+| `--bin <NAME>` | | Generate a formula for a specific binary only |
+| `--all` | | Generate formulas for all binaries (default when more than one exists) |
+| `--output-dir <DIR>` | `-o` | Write formula files to this directory |
+| `--dry-run` | | Preview formulas without writing files |
+| `--template <FILE>` | `-t` | Use a custom formula template (upon/Jinja2 syntax) |
+
+## `formulaic.toml`
+
+For non-Rust projects, create a `formulaic.toml` (or `.formulaic.toml`, or `.config/formulaic.toml`) with your project metadata:
+
+```toml
+name = "my-tool"
+version = "1.0.0"
+description = "What my tool does"
+homepage = "https://github.com/owner/my-tool"
+license = "MIT"
+repository = "https://github.com/owner/my-tool"
+gh-cli-strategy = true
+```
+
+Required fields: `name`, `version`. All others are optional.
+
+Setting `gh-cli-strategy = true` in the manifest is equivalent to passing `--gh-cli-strategy` on the command line. The CLI flag and the manifest field are OR'd together — either one enables the strategy.
+
+## The `gh` CLI download strategy
+
+The `--gh-cli-strategy` flag generates a formula with an embedded download strategy that uses the [`gh` CLI tool](https://cli.github.com). This lets an authenticated `gh` download release artifacts from private repos, assuming you can tap the repo to begin with. This is not an official Homebrew strategy, but a best-effort implementation.
 
 ## Examples
 
@@ -35,10 +59,8 @@ Options:
 
 ## Limitations
 
-The GitHub CLI download strategy is not an official homebrew strategy, but instead my best take on what one should be. It's undoubtedly less bomb-proof than one the official project would write.
+Multi-binary support (`--bin`, `--all`) works for Cargo projects but is stubbed for generic manifests — a `formulaic.toml` project always produces a single formula. Workspace support is untested.
 
-I should probably make this iterate through all discovered bins in a manifest. I only had examples with single bin targets. I also haven't tested this at all with workspaces. The manifest-reading crate, [cargo_toml](https://lib.rs/crates/cargo_toml), should be doing a good job handling them, however.
-
-## LICENSE
+## License
 
 This code is licensed via [the Parity Public License.](https://paritylicense.com) This license requires people who build on top of this source code to share their work with the community, too. See the license text for details.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,59 @@
 pub use std::collections::{BTreeMap, HashMap};
 use std::io::Read;
+use std::path::Path;
 
 pub use anyhow::{self, Context};
 pub use cargo_toml::Manifest;
+use serde::Deserialize;
 use sha2::{Digest, Sha256};
 
 static FORMULA_TMPL: &str = include_str!("formula.rb");
 static GH_FORMULA_TMPL: &str = include_str!("gh_strategy.rb");
+
+/// Metadata from a `formulaic.toml` file, for non-Cargo projects.
+#[derive(Debug, Clone, Deserialize)]
+pub struct GenericManifest {
+    pub name: String,
+    pub version: String,
+    #[serde(default)]
+    pub description: Option<String>,
+    #[serde(default)]
+    pub homepage: Option<String>,
+    #[serde(default)]
+    pub license: Option<String>,
+    #[serde(default)]
+    pub repository: Option<String>,
+}
+
+impl GenericManifest {
+    pub fn from_path(path: &Path) -> anyhow::Result<Self> {
+        let content =
+            std::fs::read_to_string(path).with_context(|| format!("Failed to read {}", path.display()))?;
+        let manifest: Self =
+            toml::from_str(&content).with_context(|| format!("Failed to parse {}", path.display()))?;
+        Ok(manifest)
+    }
+
+    /// Extract (owner, repo) from the repository URL.
+    pub fn owner_repo(&self) -> anyhow::Result<(String, String)> {
+        let repository = self
+            .repository
+            .as_deref()
+            .with_context(|| "formulaic.toml must have a repository field")?;
+        parse_owner_repo(repository)
+    }
+}
+
+/// Parse a GitHub repository URL into (owner, repo).
+pub fn parse_owner_repo(repository: &str) -> anyhow::Result<(String, String)> {
+    let mut chunks: Vec<&str> = repository.split('/').collect();
+    let repo = chunks
+        .pop()
+        .with_context(|| "Invalid repository URL format")?
+        .trim_end_matches(".git");
+    let owner = chunks.pop().with_context(|| "Invalid repository URL format")?;
+    Ok((owner.to_string(), repo.to_string()))
+}
 
 #[derive(Debug, Clone)]
 pub struct BinaryInfo {
@@ -65,6 +112,30 @@ impl AssetMatcher {
             }
         }
         None
+    }
+
+    /// Check if an asset name refers to a universal (fat) macOS binary.
+    pub fn is_universal(&self, asset_name: &str) -> bool {
+        asset_name.contains("universal-apple-darwin")
+    }
+
+    /// Extract all platforms an asset supports. Universal macOS binaries
+    /// expand to both arm and intel entries.
+    pub fn extract_platforms(&self, asset_name: &str) -> Vec<(&'static str, &'static str)> {
+        if self.is_universal(asset_name) {
+            return vec![("mac", "arm"), ("mac", "intel")];
+        }
+        self.extract_platform(asset_name).into_iter().collect()
+    }
+
+    /// Check whether the portion of the filename after the binary name prefix
+    /// matches a known target triple or a universal binary pattern.
+    pub fn matches_target(&self, after_prefix: &str) -> bool {
+        after_prefix.starts_with("universal-apple-darwin")
+            || self
+                .target_mappings
+                .keys()
+                .any(|target| after_prefix.starts_with(target))
     }
 }
 
@@ -130,6 +201,23 @@ pub fn create_base_context(manifest: &Manifest, binary: &BinaryInfo) -> anyhow::
     })
 }
 
+pub fn create_base_context_from_generic(manifest: &GenericManifest) -> FormulaContext {
+    use heck::ToUpperCamelCase;
+
+    FormulaContext {
+        package: manifest.name.to_upper_camel_case(),
+        description: manifest.description.clone().unwrap_or_default(),
+        executable: manifest.name.clone(),
+        homepage: manifest.homepage.clone().unwrap_or_default(),
+        version: manifest.version.clone(),
+        license: manifest
+            .license
+            .clone()
+            .unwrap_or_else(|| "unlicensed".to_string()),
+        assets: Vec::new(),
+    }
+}
+
 impl Asset {
     pub fn from_release_asset(v: &roctogen::models::ReleaseAsset, matcher: &AssetMatcher) -> anyhow::Result<Self> {
         let filename = v
@@ -169,6 +257,55 @@ impl Asset {
             digest,
             url: url.to_owned(),
         })
+    }
+
+    /// Create assets from a release asset that may be a universal binary.
+    /// Universal binaries produce two assets (arm + intel); others produce one.
+    pub fn assets_from_release_asset(
+        v: &roctogen::models::ReleaseAsset,
+        matcher: &AssetMatcher,
+    ) -> anyhow::Result<Vec<Self>> {
+        let filename = v
+            .name
+            .as_ref()
+            .with_context(|| format!("asset {:?} has an empty name", v.id))?;
+
+        if !filename.ends_with(".tar.gz") {
+            anyhow::bail!("asset {:?} is not a tarball", v.id);
+        }
+
+        let url = v
+            .browser_download_url
+            .as_ref()
+            .with_context(|| format!("asset {:?} doesn't have a download url", v.id))?;
+
+        let digest = if let Some(ref digest) = v.digest {
+            digest.split_once(':').map(|split| split.1.to_owned())
+        } else {
+            None
+        };
+
+        let digest = if let Some(d) = digest {
+            d
+        } else {
+            find_digest(filename.as_str(), url.as_str())
+                .with_context(|| format!("Cannot calculate digest for asset {filename}"))?
+        };
+
+        let platforms = matcher.extract_platforms(filename);
+        if platforms.is_empty() {
+            anyhow::bail!("Cannot determine platform for asset {filename}");
+        }
+
+        Ok(platforms
+            .into_iter()
+            .map(|(os, cpu)| Self {
+                cpu: cpu.to_string(),
+                os: os.to_string(),
+                digest: digest.clone(),
+                url: url.to_owned(),
+            })
+            .collect())
     }
 }
 
@@ -230,9 +367,15 @@ pub fn find_digest(filename: &str, url: &str) -> anyhow::Result<String> {
     Ok(hex::encode(digest))
 }
 
-pub fn render_to_string(use_gh: bool, context: &FormulaContext) -> anyhow::Result<String> {
+pub fn render_to_string(
+    use_gh: bool,
+    custom_template: Option<&str>,
+    context: &FormulaContext,
+) -> anyhow::Result<String> {
     let mut engine = upon::Engine::new();
-    if use_gh {
+    if let Some(tmpl) = custom_template {
+        engine.add_template("formula", tmpl)?;
+    } else if use_gh {
         engine.add_template("formula", GH_FORMULA_TMPL)?;
     } else {
         engine.add_template("formula", FORMULA_TMPL)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,14 +23,14 @@ pub struct GenericManifest {
     pub license: Option<String>,
     #[serde(default)]
     pub repository: Option<String>,
+    #[serde(default, rename = "gh-cli-strategy")]
+    pub use_gh_strategy: Option<bool>,
 }
 
 impl GenericManifest {
     pub fn from_path(path: &Path) -> anyhow::Result<Self> {
-        let content =
-            std::fs::read_to_string(path).with_context(|| format!("Failed to read {}", path.display()))?;
-        let manifest: Self =
-            toml::from_str(&content).with_context(|| format!("Failed to parse {}", path.display()))?;
+        let content = std::fs::read_to_string(path).with_context(|| format!("Failed to read {}", path.display()))?;
+        let manifest: Self = toml::from_str(&content).with_context(|| format!("Failed to parse {}", path.display()))?;
         Ok(manifest)
     }
 
@@ -210,10 +210,7 @@ pub fn create_base_context_from_generic(manifest: &GenericManifest) -> FormulaCo
         executable: manifest.name.clone(),
         homepage: manifest.homepage.clone().unwrap_or_default(),
         version: manifest.version.clone(),
-        license: manifest
-            .license
-            .clone()
-            .unwrap_or_else(|| "unlicensed".to_string()),
+        license: manifest.license.clone().unwrap_or_else(|| "unlicensed".to_string()),
         assets: Vec::new(),
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,9 +9,8 @@ use clap::Parser;
 use clap::builder::Styles;
 use clap::builder::styling::AnsiColor;
 use formulaic::{
-    Asset, AssetMatcher, FormulaContext, GenericManifest, create_base_context,
-    create_base_context_from_generic, find_digest, get_binaries_from_manifest, parse_owner_repo,
-    render_to_string,
+    Asset, AssetMatcher, FormulaContext, GenericManifest, create_base_context, create_base_context_from_generic,
+    find_digest, get_binaries_from_manifest, parse_owner_repo, render_to_string,
 };
 use roctogen::endpoints::repos;
 use roctokit::adapters::client;
@@ -25,7 +24,8 @@ use roctokit::auth::Auth;
 /// Requires a valid github token in GITHUB_ACCESS_TOKEN or GITHUB_TOKEN.
 struct Args {
     /// Path to the manifest file (Cargo.toml or formulaic.toml).
-    /// If omitted, looks for formulaic.toml then Cargo.toml in the current directory.
+    /// If omitted, looks for .config/formulaic.toml, .formulaic.toml,
+    /// formulaic.toml, then Cargo.toml in the current directory.
     manifest: Option<String>,
     /// Use the `gh` cli download strategy; useful for private tap repos
     #[arg(long = "gh-cli-strategy", short = 'g')]
@@ -67,31 +67,35 @@ enum ResolvedManifest {
 /// Resolve which manifest to use.
 ///
 /// 1. If a path is given explicitly, detect type by filename.
-/// 2. Otherwise try `formulaic.toml` then `Cargo.toml` in cwd.
+/// 2. Otherwise try `.config/formulaic.toml`, `.formulaic.toml`,
+///    `formulaic.toml`, then `Cargo.toml` in cwd.
 fn resolve_manifest(explicit: Option<&str>) -> anyhow::Result<ResolvedManifest> {
     if let Some(path) = explicit {
         if path.ends_with("formulaic.toml") {
             let manifest = GenericManifest::from_path(path.as_ref())?;
             return Ok(ResolvedManifest::Generic { manifest });
         }
-        let manifest = Manifest::from_path(path)
-            .with_context(|| format!("Failed to read manifest at {path}"))?;
+        let manifest = Manifest::from_path(path).with_context(|| format!("Failed to read manifest at {path}"))?;
         return Ok(ResolvedManifest::Cargo {
             path: path.to_string(),
             manifest: Box::new(manifest),
         });
     }
 
-    // Auto-detect: try formulaic.toml first, then Cargo.toml
-    let formulaic_path = PathBuf::from("./formulaic.toml");
-    if formulaic_path.exists() {
-        let manifest = GenericManifest::from_path(&formulaic_path)?;
-        return Ok(ResolvedManifest::Generic { manifest });
+    // Auto-detect: try formulaic.toml variants, then Cargo.toml
+    let candidates = [".config/formulaic.toml", ".formulaic.toml", "formulaic.toml"];
+    for candidate in &candidates {
+        let path = PathBuf::from(candidate);
+        if path.exists() {
+            let manifest = GenericManifest::from_path(&path)?;
+            return Ok(ResolvedManifest::Generic { manifest });
+        }
     }
 
     let cargo_path = "./Cargo.toml";
-    let manifest = Manifest::from_path(cargo_path)
-        .with_context(|| "No formulaic.toml or Cargo.toml found in current directory")?;
+    let manifest = Manifest::from_path(cargo_path).with_context(
+        || "No formulaic.toml (or .formulaic.toml, .config/formulaic.toml) or Cargo.toml found in current directory",
+    )?;
     Ok(ResolvedManifest::Cargo {
         path: cargo_path.to_string(),
         manifest: Box::new(manifest),
@@ -145,16 +149,13 @@ fn fetch_local_assets(
     let dist_dir = manifest_dir.join("dist");
 
     if !dist_dir.is_dir() {
-        anyhow::bail!(
-            "No dist/ directory found at {} for local mode",
-            dist_dir.display()
-        );
+        anyhow::bail!("No dist/ directory found at {} for local mode", dist_dir.display());
     }
 
     let matcher = AssetMatcher::new();
 
-    for entry in
-        std::fs::read_dir(&dist_dir).with_context(|| format!("Failed to read dist directory: {}", dist_dir.display()))?
+    for entry in std::fs::read_dir(&dist_dir)
+        .with_context(|| format!("Failed to read dist directory: {}", dist_dir.display()))?
     {
         let entry = entry?;
         let fullpath = entry.path();
@@ -173,9 +174,8 @@ fn fetch_local_assets(
                 if matcher.matches_target(after_prefix) {
                     let platforms = matcher.extract_platforms(&basename_str);
                     if !platforms.is_empty() {
-                        let url = format!(
-                            "https://github.com/{owner}/{repo}/releases/download/v{version}/{basename_str}"
-                        );
+                        let url =
+                            format!("https://github.com/{owner}/{repo}/releases/download/v{version}/{basename_str}");
                         let path_str = fullpath.to_string_lossy();
                         if let Ok(digest) = find_digest(&path_str, &url) {
                             for (os, cpu) in platforms {
@@ -275,7 +275,9 @@ fn main() -> anyhow::Result<()> {
                 // For generic manifests, use cwd as the manifest directory
                 let manifest_dir = if let Some(ref path) = args.manifest {
                     let p = PathBuf::from(path);
-                    p.parent().map(|d| d.to_path_buf()).unwrap_or_else(|| PathBuf::from("."))
+                    p.parent()
+                        .map(|d| d.to_path_buf())
+                        .unwrap_or_else(|| PathBuf::from("."))
                 } else {
                     PathBuf::from(".")
                 };
@@ -286,8 +288,9 @@ fn main() -> anyhow::Result<()> {
                 anyhow::bail!("GitHub client not available");
             }
 
+            let use_gh = args.use_gh_strategy || manifest.use_gh_strategy.unwrap_or(false);
             let formula_path = render_formula(
-                args.use_gh_strategy,
+                use_gh,
                 custom_template,
                 &context,
                 args.output_dir.as_ref(),
@@ -302,11 +305,7 @@ fn main() -> anyhow::Result<()> {
             let binaries = get_binaries_from_manifest(&manifest, args.bin.as_deref())?;
 
             let process_all = args.all || (binaries.len() > 1 && args.bin.is_none());
-            let binaries_to_process = if process_all {
-                &binaries[..]
-            } else {
-                &binaries[..1]
-            };
+            let binaries_to_process = if process_all { &binaries[..] } else { &binaries[..1] };
 
             let Some(ref package) = manifest.package else {
                 anyhow::bail!("The Rust project must have at least one package in it.");

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,9 @@ use clap::Parser;
 use clap::builder::Styles;
 use clap::builder::styling::AnsiColor;
 use formulaic::{
-    Asset, AssetMatcher, FormulaContext, create_base_context, find_digest, get_binaries_from_manifest, render_to_string,
+    Asset, AssetMatcher, FormulaContext, GenericManifest, create_base_context,
+    create_base_context_from_generic, find_digest, get_binaries_from_manifest, parse_owner_repo,
+    render_to_string,
 };
 use roctogen::endpoints::repos;
 use roctokit::adapters::client;
@@ -17,13 +19,14 @@ use roctokit::auth::Auth;
 
 #[derive(Debug, Clone, Parser)]
 #[clap(author, version, styles = v3_styles())]
-/// Generates Homebrew formula files for Rust binaries from their Cargo manifest.
+/// Generates Homebrew formula files for Rust binaries from their Cargo manifest,
+/// or for any project with a formulaic.toml file.
 ///
 /// Requires a valid github token in GITHUB_ACCESS_TOKEN or GITHUB_TOKEN.
 struct Args {
-    /// Path to the Cargo.toml file for the installable binary
-    #[arg(default_value = "./Cargo.toml")]
-    manifest: String,
+    /// Path to the manifest file (Cargo.toml or formulaic.toml).
+    /// If omitted, looks for formulaic.toml then Cargo.toml in the current directory.
+    manifest: Option<String>,
     /// Use the `gh` cli download strategy; useful for private tap repos
     #[arg(long = "gh-cli-strategy", short = 'g')]
     use_gh_strategy: bool,
@@ -42,6 +45,9 @@ struct Args {
     /// Preview formulas without writing files
     #[arg(long = "dry-run")]
     dry_run: bool,
+    /// Path to a custom formula template file (upon/Jinja2 syntax)
+    #[arg(long = "template", short = 't')]
+    template: Option<PathBuf>,
 }
 
 fn v3_styles() -> Styles {
@@ -52,27 +58,52 @@ fn v3_styles() -> Styles {
         .placeholder(AnsiColor::Green.on_default())
 }
 
-fn make_context_from_github(
+/// What kind of manifest we resolved.
+enum ResolvedManifest {
+    Cargo { path: String, manifest: Box<Manifest> },
+    Generic { manifest: GenericManifest },
+}
+
+/// Resolve which manifest to use.
+///
+/// 1. If a path is given explicitly, detect type by filename.
+/// 2. Otherwise try `formulaic.toml` then `Cargo.toml` in cwd.
+fn resolve_manifest(explicit: Option<&str>) -> anyhow::Result<ResolvedManifest> {
+    if let Some(path) = explicit {
+        if path.ends_with("formulaic.toml") {
+            let manifest = GenericManifest::from_path(path.as_ref())?;
+            return Ok(ResolvedManifest::Generic { manifest });
+        }
+        let manifest = Manifest::from_path(path)
+            .with_context(|| format!("Failed to read manifest at {path}"))?;
+        return Ok(ResolvedManifest::Cargo {
+            path: path.to_string(),
+            manifest: Box::new(manifest),
+        });
+    }
+
+    // Auto-detect: try formulaic.toml first, then Cargo.toml
+    let formulaic_path = PathBuf::from("./formulaic.toml");
+    if formulaic_path.exists() {
+        let manifest = GenericManifest::from_path(&formulaic_path)?;
+        return Ok(ResolvedManifest::Generic { manifest });
+    }
+
+    let cargo_path = "./Cargo.toml";
+    let manifest = Manifest::from_path(cargo_path)
+        .with_context(|| "No formulaic.toml or Cargo.toml found in current directory")?;
+    Ok(ResolvedManifest::Cargo {
+        path: cargo_path.to_string(),
+        manifest: Box::new(manifest),
+    })
+}
+
+fn fetch_github_assets(
     context: &mut FormulaContext,
-    manifest: &Manifest,
+    owner: &str,
+    repo: &str,
     github: &roctokit::adapters::ureq::Client,
 ) -> anyhow::Result<()> {
-    let Some(ref package) = manifest.package else {
-        anyhow::bail!("The Rust project must have at least one package in it.");
-    };
-
-    let repository = package
-        .repository()
-        .with_context(|| "Package must have a repository field for GitHub API access")?;
-
-    let mut chunks: Vec<&str> = repository.split('/').collect();
-    let repo = chunks
-        .pop()
-        .with_context(|| "Invalid repository URL format")?
-        .trim_end_matches(".git");
-    let owner = chunks.pop().with_context(|| "Invalid repository URL format")?;
-
-    // Gather release information
     let repo_api = repos::new(github);
     let latest_release = repo_api
         .get_latest_release(owner, repo)
@@ -82,20 +113,15 @@ fn make_context_from_github(
 
     if let Some(ref assets) = latest_release.assets {
         for asset in assets {
-            // Only include assets that match the current binary exactly
             if let Some(ref asset_name) = asset.name {
                 let expected_prefix = format!("{}-", context.executable);
                 if asset_name.starts_with(&expected_prefix) {
                     let after_prefix = &asset_name[expected_prefix.len()..];
 
-                    // Check if what comes after the prefix starts with a target triple
-                    let is_direct_target = matcher
-                        .target_mappings
-                        .keys()
-                        .any(|target| after_prefix.starts_with(target));
-
-                    if is_direct_target && let Ok(mapped) = Asset::from_release_asset(asset, &matcher) {
-                        context.assets.push(mapped);
+                    if matcher.matches_target(after_prefix)
+                        && let Ok(mapped) = Asset::assets_from_release_asset(asset, &matcher)
+                    {
+                        context.assets.extend(mapped);
                     }
                 }
             }
@@ -109,39 +135,27 @@ fn make_context_from_github(
     Ok(())
 }
 
-fn make_context_local_new(
+fn fetch_local_assets(
     context: &mut FormulaContext,
-    manifest: &Manifest,
-    manifest_path: &str,
+    owner: &str,
+    repo: &str,
+    version: &str,
+    manifest_dir: &std::path::Path,
 ) -> anyhow::Result<()> {
-    let Some(ref package) = manifest.package else {
-        anyhow::bail!("The Rust project must have at least one package in it.");
-    };
+    let dist_dir = manifest_dir.join("dist");
 
-    let version = package.version().to_string();
-    let repository = package
-        .repository()
-        .with_context(|| "Package must have a repository field for local mode")?;
-
-    let mut chunks: Vec<&str> = repository.split('/').collect();
-    let repo = chunks
-        .pop()
-        .with_context(|| "Invalid repository URL format")?
-        .trim_end_matches(".git");
-    let owner = chunks.pop().with_context(|| "Invalid repository URL format")?;
-
-    // Look for .tar.gz files in dist/ directory at the same level as Cargo.toml
-    let mut dir = PathBuf::from(manifest_path);
-    dir.pop();
-    dir.push("dist");
-
-    if !dir.is_dir() {
-        anyhow::bail!("No dist/ directory found next to Cargo.toml for local mode");
+    if !dist_dir.is_dir() {
+        anyhow::bail!(
+            "No dist/ directory found at {} for local mode",
+            dist_dir.display()
+        );
     }
 
     let matcher = AssetMatcher::new();
 
-    for entry in std::fs::read_dir(&dir).with_context(|| format!("Failed to read dist directory: {}", dir.display()))? {
+    for entry in
+        std::fs::read_dir(&dist_dir).with_context(|| format!("Failed to read dist directory: {}", dist_dir.display()))?
+    {
         let entry = entry?;
         let fullpath = entry.path();
 
@@ -152,30 +166,27 @@ fn make_context_local_new(
 
             let basename_str = basename.to_string_lossy();
 
-            // Check if this asset matches our target platforms AND current binary exactly
             let expected_prefix = format!("{}-", context.executable);
             if basename_str.starts_with(&expected_prefix) {
-                // For "formulaic-", we want to match "formulaic-aarch64-apple-darwin.tar.gz"
-                // but NOT "formulaic-helper-aarch64-apple-darwin.tar.gz"
                 let after_prefix = &basename_str[expected_prefix.len()..];
 
-                // Check if what comes after the prefix starts with a target triple
-                let is_direct_target = matcher
-                    .target_mappings
-                    .keys()
-                    .any(|target| after_prefix.starts_with(target));
-
-                if is_direct_target && let Some((os, cpu)) = matcher.extract_platform(&basename_str) {
-                    let url = format!("https://github.com/{owner}/{repo}/releases/download/v{version}/{basename_str}");
-
-                    let path_str = fullpath.to_string_lossy();
-                    if let Ok(digest) = find_digest(&path_str, &url) {
-                        context.assets.push(Asset {
-                            cpu: cpu.to_string(),
-                            os: os.to_string(),
-                            digest,
-                            url,
-                        });
+                if matcher.matches_target(after_prefix) {
+                    let platforms = matcher.extract_platforms(&basename_str);
+                    if !platforms.is_empty() {
+                        let url = format!(
+                            "https://github.com/{owner}/{repo}/releases/download/v{version}/{basename_str}"
+                        );
+                        let path_str = fullpath.to_string_lossy();
+                        if let Ok(digest) = find_digest(&path_str, &url) {
+                            for (os, cpu) in platforms {
+                                context.assets.push(Asset {
+                                    cpu: cpu.to_string(),
+                                    os: os.to_string(),
+                                    digest: digest.clone(),
+                                    url: url.clone(),
+                                });
+                            }
+                        }
                     }
                 }
             }
@@ -191,11 +202,12 @@ fn make_context_local_new(
 
 fn render_formula(
     use_gh: bool,
+    custom_template: Option<&str>,
     context: &FormulaContext,
     output_dir: Option<&PathBuf>,
     dry_run: bool,
 ) -> anyhow::Result<String> {
-    let rendered = render_to_string(use_gh, context)?;
+    let rendered = render_to_string(use_gh, custom_template, context)?;
     let formula_filename = format!("{}.rb", context.executable);
 
     let formula_path = if let Some(dir) = output_dir {
@@ -229,6 +241,17 @@ fn render_formula(
 fn main() -> anyhow::Result<()> {
     let args = Args::parse();
 
+    // Load custom template if specified
+    let custom_template_content = if let Some(ref path) = args.template {
+        Some(
+            std::fs::read_to_string(path)
+                .with_context(|| format!("Failed to read template file {}", path.display()))?,
+        )
+    } else {
+        None
+    };
+    let custom_template = custom_template_content.as_deref();
+
     // Get GitHub token only if we're not in local mode
     let github_client = if !args.local {
         let token = std::env::var("GITHUB_ACCESS_TOKEN")
@@ -241,46 +264,98 @@ fn main() -> anyhow::Result<()> {
         None
     };
 
-    let manifest = cargo_toml::Manifest::from_path(&args.manifest)
-        .with_context(|| format!("Failed to read manifest at {}", args.manifest))?;
+    let resolved = resolve_manifest(args.manifest.as_deref())?;
 
-    // Get all binaries we should process
-    let binaries = get_binaries_from_manifest(&manifest, args.bin.as_deref())?;
+    match resolved {
+        ResolvedManifest::Generic { manifest } => {
+            let (owner, repo) = manifest.owner_repo()?;
+            let mut context = create_base_context_from_generic(&manifest);
 
-    // Check if we should process all binaries or just one
-    let process_all = args.all || (binaries.len() > 1 && args.bin.is_none());
-    let binaries_to_process = if process_all {
-        &binaries[..]
-    } else {
-        &binaries[..1] // Just the first one
-    };
+            if args.local {
+                // For generic manifests, use cwd as the manifest directory
+                let manifest_dir = if let Some(ref path) = args.manifest {
+                    let p = PathBuf::from(path);
+                    p.parent().map(|d| d.to_path_buf()).unwrap_or_else(|| PathBuf::from("."))
+                } else {
+                    PathBuf::from(".")
+                };
+                fetch_local_assets(&mut context, &owner, &repo, &manifest.version, &manifest_dir)?;
+            } else if let Some(ref github) = github_client {
+                fetch_github_assets(&mut context, &owner, &repo, github)?;
+            } else {
+                anyhow::bail!("GitHub client not available");
+            }
 
-    let mut generated_files = Vec::new();
+            let formula_path = render_formula(
+                args.use_gh_strategy,
+                custom_template,
+                &context,
+                args.output_dir.as_ref(),
+                args.dry_run,
+            )?;
 
-    for binary in binaries_to_process {
-        let mut context = create_base_context(&manifest, binary)?;
-
-        // Populate assets based on mode
-        if args.local {
-            make_context_local_new(&mut context, &manifest, &args.manifest)?;
-        } else if let Some(ref github) = github_client {
-            make_context_from_github(&mut context, &manifest, github)?;
-        } else {
-            anyhow::bail!("GitHub client not available");
+            if !args.dry_run {
+                println!("{formula_path}");
+            }
         }
+        ResolvedManifest::Cargo { path, manifest } => {
+            let binaries = get_binaries_from_manifest(&manifest, args.bin.as_deref())?;
 
-        let formula_path = render_formula(args.use_gh_strategy, &context, args.output_dir.as_ref(), args.dry_run)?;
+            let process_all = args.all || (binaries.len() > 1 && args.bin.is_none());
+            let binaries_to_process = if process_all {
+                &binaries[..]
+            } else {
+                &binaries[..1]
+            };
 
-        generated_files.push(formula_path);
-    }
+            let Some(ref package) = manifest.package else {
+                anyhow::bail!("The Rust project must have at least one package in it.");
+            };
 
-    if !args.dry_run {
-        if generated_files.len() == 1 {
-            println!("{}", generated_files[0]);
-        } else {
-            println!("Generated {} formula files:", generated_files.len());
-            for file in &generated_files {
-                println!("  {file}");
+            let repository = package
+                .repository()
+                .with_context(|| "Package must have a repository field")?;
+            let (owner, repo) = parse_owner_repo(repository)?;
+
+            let mut generated_files = Vec::new();
+
+            for binary in binaries_to_process {
+                let mut context = create_base_context(&manifest, binary)?;
+
+                let version = context.version.clone();
+                if args.local {
+                    let manifest_dir = PathBuf::from(&path);
+                    let manifest_dir = manifest_dir
+                        .parent()
+                        .map(|d| d.to_path_buf())
+                        .unwrap_or_else(|| PathBuf::from("."));
+                    fetch_local_assets(&mut context, &owner, &repo, &version, &manifest_dir)?;
+                } else if let Some(ref github) = github_client {
+                    fetch_github_assets(&mut context, &owner, &repo, github)?;
+                } else {
+                    anyhow::bail!("GitHub client not available");
+                }
+
+                let formula_path = render_formula(
+                    args.use_gh_strategy,
+                    custom_template,
+                    &context,
+                    args.output_dir.as_ref(),
+                    args.dry_run,
+                )?;
+
+                generated_files.push(formula_path);
+            }
+
+            if !args.dry_run {
+                if generated_files.len() == 1 {
+                    println!("{}", generated_files[0]);
+                } else {
+                    println!("Generated {} formula files:", generated_files.len());
+                    for file in &generated_files {
+                        println!("  {file}");
+                    }
+                }
             }
         }
     }

--- a/tests/context_tests.rs
+++ b/tests/context_tests.rs
@@ -2,7 +2,8 @@ use std::path::PathBuf;
 
 use cargo_toml::Manifest;
 use formulaic::{
-    Asset, AssetMatcher, BinaryInfo, FormulaContext, create_base_context, get_binaries_from_manifest, render_to_string,
+    Asset, AssetMatcher, BinaryInfo, FormulaContext, GenericManifest, create_base_context,
+    create_base_context_from_generic, get_binaries_from_manifest, parse_owner_repo, render_to_string,
 };
 
 fn load_fixture(name: &str) -> Manifest {
@@ -10,6 +11,13 @@ fn load_fixture(name: &str) -> Manifest {
     path.push("tests/fixtures");
     path.push(format!("{name}.toml"));
     Manifest::from_path(path).unwrap_or_else(|_| panic!("Failed to load fixture {name}"))
+}
+
+fn load_generic_fixture(name: &str) -> GenericManifest {
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.push("tests/fixtures");
+    path.push(format!("{name}.toml"));
+    GenericManifest::from_path(&path).unwrap_or_else(|_| panic!("Failed to load generic fixture {name}"))
 }
 
 #[test]
@@ -36,10 +44,39 @@ fn can_render_template() {
             },
         ],
     };
-    let rendered = render_to_string(false, &context).expect("rendering the template failed");
+    let rendered = render_to_string(false, None, &context).expect("rendering the template failed");
     eprintln!("{rendered}");
     assert!(rendered.contains("sha256 \"cafed00d\""));
     assert!(rendered.contains("bin.install \"frobber\" if OS.mac?"));
+}
+
+#[test]
+fn can_render_custom_template() {
+    let context = FormulaContext {
+        package: "MyTool".to_string(),
+        description: "A test tool".to_string(),
+        version: "2.0.0".to_string(),
+        license: "MIT".to_string(),
+        homepage: "https://example.com".to_string(),
+        executable: "my-tool".to_string(),
+        assets: vec![Asset {
+            os: "mac".to_string(),
+            cpu: "arm".to_string(),
+            url: "https://example.com/asset.tar.gz".to_string(),
+            digest: "abc123".to_string(),
+        }],
+    };
+
+    let custom = r#"# Custom template for {{ executable }}
+class {{ package }} < Formula
+    version "{{ version }}"
+end
+"#;
+
+    let rendered = render_to_string(false, Some(custom), &context).expect("custom template rendering failed");
+    assert!(rendered.contains("# Custom template for my-tool"));
+    assert!(rendered.contains("class MyTool < Formula"));
+    assert!(rendered.contains("version \"2.0.0\""));
 }
 
 #[test]
@@ -148,6 +185,37 @@ fn asset_matcher_with_different_naming() {
 }
 
 #[test]
+fn asset_matcher_universal_binary() {
+    let matcher = AssetMatcher::new();
+
+    // Universal binary should be detected
+    assert!(matcher.is_universal("paletter-universal-apple-darwin.tar.gz"));
+    assert!(!matcher.is_universal("paletter-aarch64-apple-darwin.tar.gz"));
+
+    // extract_platforms should return both arm and intel for universal
+    let platforms = matcher.extract_platforms("paletter-universal-apple-darwin.tar.gz");
+    assert_eq!(platforms.len(), 2);
+    assert!(platforms.contains(&("mac", "arm")));
+    assert!(platforms.contains(&("mac", "intel")));
+
+    // Non-universal should return single platform
+    let platforms = matcher.extract_platforms("paletter-aarch64-apple-darwin.tar.gz");
+    assert_eq!(platforms.len(), 1);
+    assert_eq!(platforms[0], ("mac", "arm"));
+}
+
+#[test]
+fn asset_matcher_matches_target() {
+    let matcher = AssetMatcher::new();
+
+    assert!(matcher.matches_target("aarch64-apple-darwin.tar.gz"));
+    assert!(matcher.matches_target("x86_64-unknown-linux-gnu.tar.gz"));
+    assert!(matcher.matches_target("universal-apple-darwin.tar.gz"));
+    assert!(!matcher.matches_target("windows-msvc.zip"));
+    assert!(!matcher.matches_target("something-else.tar.gz"));
+}
+
+#[test]
 fn context_with_minimal_package_info() {
     let manifest = load_fixture("single-binary");
     let binary = BinaryInfo {
@@ -163,6 +231,101 @@ fn context_with_minimal_package_info() {
     assert!(!context.version.is_empty());
     // Description and homepage might be empty, that's ok
     // License should default to "unlicensed" if missing
+}
+
+// --- GenericManifest tests ---
+
+#[test]
+fn generic_manifest_full() {
+    let manifest = load_generic_fixture("generic-manifest");
+
+    assert_eq!(manifest.name, "paletter");
+    assert_eq!(manifest.version, "1.0.0");
+    assert_eq!(
+        manifest.description.as_deref(),
+        Some("Convert tinty YAML color palettes to macOS .clr files")
+    );
+    assert_eq!(
+        manifest.homepage.as_deref(),
+        Some("https://github.com/ceejbot/paletter")
+    );
+    assert_eq!(manifest.license.as_deref(), Some("Parity-7.0.0"));
+    assert_eq!(
+        manifest.repository.as_deref(),
+        Some("https://github.com/ceejbot/paletter")
+    );
+}
+
+#[test]
+fn generic_manifest_minimal() {
+    let manifest = load_generic_fixture("generic-minimal");
+
+    assert_eq!(manifest.name, "minimal-tool");
+    assert_eq!(manifest.version, "0.1.0");
+    assert!(manifest.description.is_none());
+    assert!(manifest.homepage.is_none());
+    assert!(manifest.license.is_none());
+    assert!(manifest.repository.is_none());
+}
+
+#[test]
+fn generic_manifest_owner_repo() {
+    let manifest = load_generic_fixture("generic-manifest");
+    let (owner, repo) = manifest.owner_repo().expect("should parse owner/repo");
+
+    assert_eq!(owner, "ceejbot");
+    assert_eq!(repo, "paletter");
+}
+
+#[test]
+fn generic_manifest_owner_repo_missing() {
+    let manifest = load_generic_fixture("generic-minimal");
+    let result = manifest.owner_repo();
+    assert!(result.is_err());
+}
+
+#[test]
+fn create_context_from_generic_manifest() {
+    let manifest = load_generic_fixture("generic-manifest");
+    let context = create_base_context_from_generic(&manifest);
+
+    assert_eq!(context.package, "Paletter");
+    assert_eq!(context.executable, "paletter");
+    assert_eq!(
+        context.description,
+        "Convert tinty YAML color palettes to macOS .clr files"
+    );
+    assert_eq!(context.homepage, "https://github.com/ceejbot/paletter");
+    assert_eq!(context.version, "1.0.0");
+    assert_eq!(context.license, "Parity-7.0.0");
+    assert!(context.assets.is_empty());
+}
+
+#[test]
+fn create_context_from_generic_minimal() {
+    let manifest = load_generic_fixture("generic-minimal");
+    let context = create_base_context_from_generic(&manifest);
+
+    assert_eq!(context.package, "MinimalTool");
+    assert_eq!(context.executable, "minimal-tool");
+    assert_eq!(context.description, "");
+    assert_eq!(context.homepage, "");
+    assert_eq!(context.version, "0.1.0");
+    assert_eq!(context.license, "unlicensed");
+}
+
+#[test]
+fn parse_owner_repo_https() {
+    let (owner, repo) = parse_owner_repo("https://github.com/ceejbot/formulaic").expect("should parse");
+    assert_eq!(owner, "ceejbot");
+    assert_eq!(repo, "formulaic");
+}
+
+#[test]
+fn parse_owner_repo_git_suffix() {
+    let (owner, repo) = parse_owner_repo("https://github.com/ceejbot/formulaic.git").expect("should parse");
+    assert_eq!(owner, "ceejbot");
+    assert_eq!(repo, "formulaic");
 }
 
 #[test]

--- a/tests/context_tests.rs
+++ b/tests/context_tests.rs
@@ -329,6 +329,38 @@ fn parse_owner_repo_git_suffix() {
 }
 
 #[test]
+fn generic_manifest_with_gh_strategy() {
+    let toml = r#"
+        name = "test-tool"
+        version = "1.0.0"
+        gh-cli-strategy = true
+    "#;
+    let manifest: GenericManifest = toml::from_str(toml).expect("should parse");
+    assert_eq!(manifest.use_gh_strategy, Some(true));
+}
+
+#[test]
+fn generic_manifest_without_gh_strategy() {
+    let toml = r#"
+        name = "test-tool"
+        version = "1.0.0"
+    "#;
+    let manifest: GenericManifest = toml::from_str(toml).expect("should parse");
+    assert_eq!(manifest.use_gh_strategy, None);
+}
+
+#[test]
+fn generic_manifest_gh_strategy_false() {
+    let toml = r#"
+        name = "test-tool"
+        version = "1.0.0"
+        gh-cli-strategy = false
+    "#;
+    let manifest: GenericManifest = toml::from_str(toml).expect("should parse");
+    assert_eq!(manifest.use_gh_strategy, Some(false));
+}
+
+#[test]
 #[ignore] // Workspace members need to be tested differently
 fn workspace_member_context() {
     // This test is disabled because cargo_toml requires workspace members

--- a/tests/fixtures/generic-manifest.toml
+++ b/tests/fixtures/generic-manifest.toml
@@ -1,0 +1,6 @@
+name = "paletter"
+version = "1.0.0"
+description = "Convert tinty YAML color palettes to macOS .clr files"
+homepage = "https://github.com/ceejbot/paletter"
+license = "Parity-7.0.0"
+repository = "https://github.com/ceejbot/paletter"

--- a/tests/fixtures/generic-minimal.toml
+++ b/tests/fixtures/generic-minimal.toml
@@ -1,0 +1,2 @@
+name = "minimal-tool"
+version = "0.1.0"


### PR DESCRIPTION
You can now generate formula files for anything you want using a toml 
manifest file. This manifest lets you specify for anything the things
the tool otherwise finds inside Cargo.toml

Search path for package information:
`.config/formulaic.toml` 
    -> `.formulaic.toml` 
    -> `formulaic.toml` 
    -> `Cargo.toml`

You can pass a custom template with `--template FILE`. Write templates
using the `upon` template syntax: https://lib.rs/crates/upon

- Updated dependencies.
- Updated tool usage in the justfile. 
- Updated the README.